### PR TITLE
Store url as a stored property instead of computed property

### DIFF
--- a/Examples/XCResourceExample/XCResourceExampleLib/Sources/Resources/ResourceAccess/FileResource.swift
+++ b/Examples/XCResourceExample/XCResourceExampleLib/Sources/Resources/ResourceAccess/FileResource.swift
@@ -6,14 +6,12 @@ import Foundation
 public struct FileResource: Hashable, Sendable {
     public let relativePath: String
     public let bundle: Bundle
+    public let url: URL
     
     public init(relativePath: String, bundle: Bundle) {
         self.relativePath = relativePath
         self.bundle = bundle
-    }
-    
-    public var url: URL {
-        return URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
+        self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
     }
     
     public var path: String {

--- a/Examples/XCResourceExample/XCResourceExampleLib/Sources/Resources/ResourceAccess/FontResource.swift
+++ b/Examples/XCResourceExample/XCResourceExampleLib/Sources/Resources/ResourceAccess/FontResource.swift
@@ -11,6 +11,7 @@ public struct FontResource: Equatable, Sendable {
     public let symbolicTraits: CTFontSymbolicTraits
     public let relativePath: String
     public let bundle: Bundle
+    public let url: URL
     
     public init(
         fontName: String,
@@ -26,10 +27,7 @@ public struct FontResource: Equatable, Sendable {
         self.symbolicTraits = symbolicTraits
         self.relativePath = relativePath
         self.bundle = bundle
-    }
-    
-    public var url: URL {
-        return URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
+        self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
     }
     
     public var path: String {

--- a/Sources/FileResourceGen/CodeGenerator/DefaultTypeDeclarationGenerator.swift
+++ b/Sources/FileResourceGen/CodeGenerator/DefaultTypeDeclarationGenerator.swift
@@ -4,18 +4,19 @@ class DefaultTypeDeclarationGenerator: TypeDeclarationGenerator {
     func generate(resourceTypeName: String, accessLevel: String?) -> String {
         let accessLevel = accessLevel.map({ $0 + " " }) ?? ""
         
+        // let url = URL(filePath: "Library", relativeTo: URL(fileURLWithPath: "/System"))
+        // print(url.path(percentEncoded: false)) // iOS18: Library, iOS26: /System/Library
+        // print(url.standardizedFileURL.path(percentEncoded: false)) // All: /System/Library
         return """
             \(accessLevel)struct \(resourceTypeName): Hashable, Sendable {
                 \(accessLevel)let relativePath: String
                 \(accessLevel)let bundle: Bundle
+                \(accessLevel)let url: URL
                 
                 \(accessLevel)init(relativePath: String, bundle: Bundle) {
                     self.relativePath = relativePath
                     self.bundle = bundle
-                }
-                
-                \(accessLevel)var url: URL {
-                    return URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
+                    self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
             .standardizedFileURL
                 }
                 

--- a/Sources/FontResourceGen/CodeGenerator/DefaultTypeDeclarationGenerator.swift
+++ b/Sources/FontResourceGen/CodeGenerator/DefaultTypeDeclarationGenerator.swift
@@ -4,6 +4,9 @@ class DefaultTypeDeclarationGenerator: TypeDeclarationGenerator {
     func generate(resourceTypeName: String, accessLevel: String?) -> String {
         let accessLevel = accessLevel.map({ $0 + " " }) ?? ""
         
+        // let url = URL(filePath: "Library", relativeTo: URL(fileURLWithPath: "/System"))
+        // print(url.path(percentEncoded: false)) // iOS18: Library, iOS26: /System/Library
+        // print(url.standardizedFileURL.path(percentEncoded: false)) // All: /System/Library
         return """
             \(accessLevel)struct \(resourceTypeName): Equatable, Sendable {
                 \(accessLevel)let fontName: String
@@ -12,6 +15,7 @@ class DefaultTypeDeclarationGenerator: TypeDeclarationGenerator {
                 \(accessLevel)let symbolicTraits: CTFontSymbolicTraits
                 \(accessLevel)let relativePath: String
                 \(accessLevel)let bundle: Bundle
+                \(accessLevel)let url: URL
                 
                 \(accessLevel)init(
                     fontName: String,
@@ -27,10 +31,7 @@ class DefaultTypeDeclarationGenerator: TypeDeclarationGenerator {
                     self.symbolicTraits = symbolicTraits
                     self.relativePath = relativePath
                     self.bundle = bundle
-                }
-                
-                \(accessLevel)var url: URL {
-                    return URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
+                    self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
             .standardizedFileURL
                 }
                 

--- a/Tests/XCResourceCommandTests/Commands/FilesToSwiftTests.swift
+++ b/Tests/XCResourceCommandTests/Commands/FilesToSwiftTests.swift
@@ -14,14 +14,13 @@ private enum Fixture {
     public struct FileResource: Hashable, Sendable {
         public let relativePath: String
         public let bundle: Bundle
+        public let url: URL
         
         public init(relativePath: String, bundle: Bundle) {
             self.relativePath = relativePath
             self.bundle = bundle
-        }
-        
-        public var url: URL {
-            return URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
+            self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
+    .standardizedFileURL
         }
         
         public var path: String {

--- a/Tests/XCResourceCommandTests/Commands/FontsToSwiftTests.swift
+++ b/Tests/XCResourceCommandTests/Commands/FontsToSwiftTests.swift
@@ -19,6 +19,7 @@ private enum Fixture {
         public let symbolicTraits: CTFontSymbolicTraits
         public let relativePath: String
         public let bundle: Bundle
+        public let url: URL
         
         public init(
             fontName: String,
@@ -34,10 +35,8 @@ private enum Fixture {
             self.symbolicTraits = symbolicTraits
             self.relativePath = relativePath
             self.bundle = bundle
-        }
-        
-        public var url: URL {
-            return URL(filePath: relativePath, relativeTo: bundle.resourceURL).standardizedFileURL
+            self.url = URL(filePath: relativePath, relativeTo: bundle.resourceURL)\
+    .standardizedFileURL
         }
         
         public var path: String {


### PR DESCRIPTION
## Summary
- Change the generated `url` from a computed property to a stored property, computed once in `init`.

## Why
On versions below iOS 26, `URL.path(percentEncoded:)` misbehaves, so `standardizedFileURL` is used to get a correct path. Because `standardizedFileURL` is relatively expensive, computing it on every `url` access (as a computed property) is wasteful — so it is now computed once in `init` and stored.
```swift
let url = URL(filePath: "Library", relativeTo: URL(fileURLWithPath: "/System"))
print(url.path(percentEncoded: false)) // iOS18: Library, iOS26: /System/Library
print(url.standardizedFileURL.path(percentEncoded: false)) // All: /System/Library
```